### PR TITLE
Added default_search_filter options. Similar to 'default_scope' of Activerecord

### DIFF
--- a/test/integration/active_model_searchable_test.rb
+++ b/test/integration/active_model_searchable_test.rb
@@ -84,6 +84,29 @@ module Tire
         assert_equal 'abc123', results.first.id
       end
 
+      context "with default filter" do
+        setup do
+          SupermodelArticleWithDefaultFilter.index.delete
+          SupermodelArticleWithDefaultFilter.create! :title => 'foo', :status => 'active'
+          SupermodelArticleWithDefaultFilter.create! :title => 'foo', :status => 'inactive'
+          SupermodelArticleWithDefaultFilter.index.refresh
+        end
+
+        should "search with default filter" do
+          results = SupermodelArticleWithDefaultFilter.search 'foo'
+
+          assert_equal 1, results.count
+          assert_equal false, results.to_a.collect(&:status).include?('inactive')
+        end
+
+        should "not search with default filter when unscoped options is true" do
+          results = SupermodelArticleWithDefaultFilter.search 'foo', :unscoped => true
+
+          assert_equal 2, results.count
+          assert_equal true, results.to_a.collect(&:status).include?('inactive')
+        end
+      end
+
       context "within Rails" do
 
         setup do

--- a/test/models/supermodel_article_with_default_filter.rb
+++ b/test/models/supermodel_article_with_default_filter.rb
@@ -1,0 +1,24 @@
+# Example ActiveModel class for testing :searchable mode
+
+require 'rubygems'
+require 'supermodel'
+
+class SupermodelArticleWithDefaultFilter < SuperModel::Base
+  include SuperModel::RandomID
+
+  include Tire::Model::Search
+  include Tire::Model::Callbacks
+
+  mapping do
+    indexes :title,      :type => 'string', :boost => 15, :analyzer => 'czech'
+    indexes :status,      :type => 'string'
+  end
+
+  default_search_filter :status => 'active'
+
+  alias :persisted? :exists?
+
+  def destroyed?
+    !self.class.find(self.id) rescue true
+  end
+end

--- a/test/unit/model_search_test.rb
+++ b/test/unit/model_search_test.rb
@@ -153,6 +153,30 @@ module Tire
             end
           end
 
+          context "with default filter" do
+
+            setup do
+              ActiveModelArticle.default_search_filter :status => 'active'
+            end
+
+            should "filter with default filter" do
+              Tire::Search::Search.any_instance.expects(:filter).with(:term, :status => 'active')
+              ActiveModelArticle.search 'foo'
+              ActiveModelArticle.default_search_filter nil
+            end
+
+            should "not filter with default filter when unscoped option is true" do
+              Tire::Search::Search.any_instance.expects(:filter).with(:term, :status => 'active').never
+              ActiveModelArticle.default_search_filter :status => 'active'
+              ActiveModelArticle.search 'foo', :unscoped => true
+            end
+
+            teardown do
+              ActiveModelArticle.default_search_filter nil
+            end
+
+          end
+
         end
 
         context "searching with query string" do


### PR DESCRIPTION
Hi,

I have added a commit to support default-search-filter.

When declared, it adds a term filter with the given term hash to all searches. If user wishes to search excluding this filter options[:unscoped] has to be passed as true (similar to AR).

I've added integration and unit tests as well.

Feel free to give comments. I can add/remove/modify based on that.

Thanks.
